### PR TITLE
chore: fix kpro:conn_config() typespec

### DIFF
--- a/src/kafka_protocol.app.src
+++ b/src/kafka_protocol.app.src
@@ -1,6 +1,6 @@
 {application,kafka_protocol,
              [{description,"Kafka protocol library for Erlang/Elixir"},
-              {vsn,"2.3.6.3"},
+              {vsn,"2.3.6.4"},
               {registered,[]},
               {applications,[kernel,stdlib,ssl,snappyer,crc32cer]},
               {env,[]},

--- a/src/kafka_protocol.appup.src
+++ b/src/kafka_protocol.appup.src
@@ -1,7 +1,10 @@
-%% -*-: erlang -*-
-{"2.3.6.3", %% 2.3.6 from upstream with emqx changes on top
- [{"2.3.6.2",
-   [{load_module,kpro_scram,brutal_purge,soft_purge,[]},
+%% -*- mode: erlang -*-
+{"2.3.6.4", %% 2.3.6 from upstream with emqx changes on top
+ [{"2.3.6.3",
+   [{load_module,kpro_connection,brutal_purge,soft_purge,[]}]},
+  {"2.3.6.2",
+   [{load_module,kpro_connection,brutal_purge,soft_purge,[]},
+    {load_module,kpro_scram,brutal_purge,soft_purge,[]},
     {load_module,kpro_schema,brutal_purge,soft_purge,[]},
     {load_module,kpro_lib,brutal_purge,soft_purge,[]}]},
   {<<"2\\.3\\..*">>,
@@ -13,8 +16,11 @@
     {load_module,kpro_req_lib,brutal_purge,soft_purge,[]},
     {load_module,kpro_schema,brutal_purge,soft_purge,[]},
     {load_module,kpro_scram,brutal_purge,soft_purge,[]}]}],
- [{"2.3.6.2",
-   [{load_module,kpro_scram,brutal_purge,soft_purge,[]},
+ [{"2.3.6.3",
+   [{load_module,kpro_connection,brutal_purge,soft_purge,[]}]},
+  {"2.3.6.2",
+   [{load_module,kpro_connection,brutal_purge,soft_purge,[]},
+    {load_module,kpro_scram,brutal_purge,soft_purge,[]},
     {load_module,kpro_schema,brutal_purge,soft_purge,[]},
     {load_module,kpro_lib,brutal_purge,soft_purge,[]}]},
   {<<"2\\.3\\..*">>,

--- a/src/kpro_connection.erl
+++ b/src/kpro_connection.erl
@@ -59,7 +59,7 @@
                  | ssl.
 
 -type cfg_val() :: term().
--type config() :: [{cfg_key(), cfg_val()}] | #{cfg_key() => cfg_val()}.
+-type config() :: [{cfg_key(), cfg_val()}] | #{cfg_key() => cfg_val(), any() => cfg_val()}.
 -type requests() :: kpro_sent_reqs:requests().
 -type hostname() :: kpro:hostname().
 -type portnum()  :: kpro:portnum().


### PR DESCRIPTION
In our kafka rule actions, since there are more configuration keys
being passed down that only wolff recognizes, dialyzer complains about
those unknown keys, despite all associations being marked
optional (`=>`).