### PR TITLE
chore: allow special values for SNI

### DIFF
--- a/src/kafka_protocol.app.src
+++ b/src/kafka_protocol.app.src
@@ -1,6 +1,6 @@
 {application,kafka_protocol,
              [{description,"Kafka protocol library for Erlang/Elixir"},
-              {vsn,"2.3.6.4"},
+              {vsn,"2.3.6.5"},
               {registered,[]},
               {applications,[kernel,stdlib,ssl,snappyer,crc32cer]},
               {env,[]},

--- a/src/kafka_protocol.appup.src
+++ b/src/kafka_protocol.appup.src
@@ -1,12 +1,17 @@
 %% -*-: erlang -*-
-{"2.3.6.4", %% 2.3.6 from upstream with emqx changes on top
+{"2.3.6.5", %% 2.3.6 from upstream with emqx changes on top
  [
+  {"2.3.6.4",
+   [{load_module,kpro_connection,brutal_purge,soft_purge,[]}
+   ]},
   {"2.3.6.3",
-   [{load_module,kpro_schema,brutal_purge,soft_purge,[]}
+   [{load_module,kpro_schema,brutal_purge,soft_purge,[]},
+    {load_module,kpro_connection,brutal_purge,soft_purge,[]}
    ]},
   {"2.3.6.2",
    [{load_module,kpro_scram,brutal_purge,soft_purge,[]},
     {load_module,kpro_schema,brutal_purge,soft_purge,[]},
+    {load_module,kpro_connection,brutal_purge,soft_purge,[]},
     {load_module,kpro_lib,brutal_purge,soft_purge,[]}]},
   {<<"2\\.3\\..*">>,
    [{load_module,kpro_connection,brutal_purge,soft_purge,[]},
@@ -17,12 +22,17 @@
     {load_module,kpro_req_lib,brutal_purge,soft_purge,[]},
     {load_module,kpro_schema,brutal_purge,soft_purge,[]},
     {load_module,kpro_scram,brutal_purge,soft_purge,[]}]}],
- [{"2.3.6.3",
-   [{load_module,kpro_schema,brutal_purge,soft_purge,[]}
+ [{"2.3.6.4",
+   [{load_module,kpro_connection,brutal_purge,soft_purge,[]}
+   ]},
+  {"2.3.6.3",
+   [{load_module,kpro_schema,brutal_purge,soft_purge,[]},
+    {load_module,kpro_connection,brutal_purge,soft_purge,[]}
    ]},
   {"2.3.6.2",
    [{load_module,kpro_scram,brutal_purge,soft_purge,[]},
     {load_module,kpro_schema,brutal_purge,soft_purge,[]},
+    {load_module,kpro_connection,brutal_purge,soft_purge,[]},
     {load_module,kpro_lib,brutal_purge,soft_purge,[]}]},
   {<<"2\\.3\\..*">>,
    [{load_module,kpro_connection,brutal_purge,soft_purge,[]},

--- a/src/kpro_connection.erl
+++ b/src/kpro_connection.erl
@@ -304,7 +304,7 @@ ensure_string(Host) -> Host.
 
 maybe_upgrade_to_ssl(Sock, _Mod = ssl, SslOpts0, Host, Timeout) ->
   SslOpts1 = case SslOpts0 of
-              true -> [];
+              true -> [{verify, verify_none}];
               [_|_] -> SslOpts0
             end,
   SslOpts = insert_server_name_indication(SslOpts1, Host),

--- a/test/kpro_schema_tests.erl
+++ b/test/kpro_schema_tests.erl
@@ -29,9 +29,9 @@ test_api(API) ->
 
 error_code_test() ->
     %% insure it's added (if we ever regenerate the schema module)
-    ?assertEqual(invalid_recod, kpro_schema:ec(87)),
+    ?assertEqual(invalid_record, kpro_schema:ec(87)),
     %% unknown error code should not crash
-    ?assertEqual({unknown_error_code, 99999}, kpro_schema:ec(99999)).
+    ?assertEqual(99999, kpro_schema:ec(99999)).
 
 %%%_* Emacs ====================================================================
 %%% Local Variables:

--- a/test/kpro_test_lib.erl
+++ b/test/kpro_test_lib.erl
@@ -218,6 +218,7 @@ ssl_options() ->
           [ {cacertfile, CaCertFile}
           , {keyfile,    osenv("KPRO_TEST_SSL_KEY_FILE")}
           , {certfile,   osenv("KPRO_TEST_SSL_CERT_FILE")}
+          , {verify, verify_none}
           ]
       end
   end.
@@ -237,6 +238,7 @@ default_ssl_options() ->
   [ {cacertfile, Fname("ca.crt")}
   , {keyfile,    Fname("client.key")}
   , {certfile,   Fname("client.crt")}
+  , {verify,     verify_none}
   ].
 
 osenv(Name) ->


### PR DESCRIPTION
Fixed two issues with this change

1. Prior to this change, SNI is auto-added only when SSL option 'verify' is set to 'verify_peer'. This retriction is unnecessary, because SNI is a part of client-hello in the handsake, it does not have anything to do with server certificate (and hostname) verification.

2. The connection config is shared between bootstrap connection and partition leader connection. Using a static SNI may work for bootstrap connections but may then fail for partition leaders if they happen to be different hosts (which is always the case in confluent cloud). To fix it, we now allow users to use two special values for sever_name_indication
   - auto: use the exact connecting host name (FQDN or IP)
   - none: do not use anything at all.